### PR TITLE
Make compatible with react 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "touch"
   ],
   "dependencies": {
-    "create-react-class": "^15.6.2",
     "lodash.assign": "*"
   },
   "devDependencies": {
@@ -58,7 +57,9 @@
     "react-style-sheets": "0.1.0",
     "sinon": "1.17.6",
     "sinon-chai": "2.8.0",
-    "watchify": "3.6.1"
+    "watchify": "3.6.1",
+    "create-react-class": "^15.6.2",
+    "prop-types": "^15.6.0"
   },
   "peerDependencies": {
     "react": "*"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "touch"
   ],
   "dependencies": {
+    "create-react-class": "^15.6.2",
     "lodash.assign": "*"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -746,11 +746,18 @@
   if (typeof exports === 'object' && typeof module !== 'undefined') {
     var React = require('react'); // eslint-disable-line no-undef
     var ReactDOM = require('react-dom'); // eslint-disable-line no-undef
+    if (!React.createClass) {
+      React.createClass = require('create-react-class'); // eslint-disable-line no-undef
+    }
     var assign = require('lodash.assign'); // eslint-disable-line no-undef
     module.exports = withReorderMethods(getReorderComponent(React, ReactDOM, assign)); // eslint-disable-line no-undef
   // Export for amd / require
   } else if (typeof define === 'function' && define.amd) { // eslint-disable-line no-undef
-    define(['react', 'react-dom', 'lodash.assign'], function (ReactAMD, ReactDOMAMD, assignAMD) { // eslint-disable-line no-undef
+    define(['react', 'react-dom', 'lodash.assign', 'create-react-class'], // eslint-disable-line no-undef
+    function (ReactAMD, ReactDOMAMD, assignAMD, createClassAMD) {
+      if (!ReactAMD.createClass) {
+        ReactAMD.createClass = createClassAMD; // eslint-disable-line no-undef
+      }
       return withReorderMethods(getReorderComponent(ReactAMD, ReactDOMAMD, assignAMD));
     });
   // Export globally
@@ -765,6 +772,10 @@
       root = self; // eslint-disable-line no-undef
     } else {
       root = this;
+    }
+
+    if (!root.React.createClass) {
+      root.React.createClass = root.createClass;
     }
 
     root.Reorder = withReorderMethods(getReorderComponent(root.React, root.ReactDOM, root.assign));

--- a/src/index.js
+++ b/src/index.js
@@ -749,14 +749,20 @@
     if (!React.createClass) {
       React.createClass = require('create-react-class'); // eslint-disable-line no-undef
     }
+    if (!React.PropTypes) {
+      React.PropTypes = require('prop-types');
+    }
     var assign = require('lodash.assign'); // eslint-disable-line no-undef
     module.exports = withReorderMethods(getReorderComponent(React, ReactDOM, assign)); // eslint-disable-line no-undef
   // Export for amd / require
   } else if (typeof define === 'function' && define.amd) { // eslint-disable-line no-undef
-    define(['react', 'react-dom', 'lodash.assign', 'create-react-class'], // eslint-disable-line no-undef
-    function (ReactAMD, ReactDOMAMD, assignAMD, createClassAMD) {
+    define(['react', 'react-dom', 'lodash.assign', 'create-react-class', 'prop-types'], // eslint-disable-line no-undef
+    function (ReactAMD, ReactDOMAMD, assignAMD, createClassAMD, propTypesAMD) {
       if (!ReactAMD.createClass) {
         ReactAMD.createClass = createClassAMD; // eslint-disable-line no-undef
+      }
+      if (!ReactAMD.PropTypes) {
+        ReactAMD.PropTypes = propTypesAMD;
       }
       return withReorderMethods(getReorderComponent(ReactAMD, ReactDOMAMD, assignAMD));
     });
@@ -777,6 +783,11 @@
     if (!root.React.createClass) {
       root.React.createClass = root.createClass;
     }
+
+    if (!root.React.PropTypes) {
+      root.React.PropTypes = root.PropTypes;
+    }
+
 
     root.Reorder = withReorderMethods(getReorderComponent(root.React, root.ReactDOM, root.assign));
   }


### PR DESCRIPTION
createClass and PropTypes were moved into separate packages in react 16. this should not break compatibility with react 15